### PR TITLE
fixed compile error for 4.6 kernel

### DIFF
--- a/rt2x00/rt2800lib.c
+++ b/rt2x00/rt2800lib.c
@@ -8993,14 +8993,24 @@ u64 rt2800_get_tsf(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
 }
 
 int rt2800_ampdu_action(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+                        struct ieee80211_ampdu_params *params
+#else
 			enum ieee80211_ampdu_mlme_action action,
 			struct ieee80211_sta *sta, u16 tid, u16 *ssn,
 			u8 buf_size
             #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 			, bool amsdu
             #endif
+#endif
             )
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+	enum ieee80211_ampdu_mlme_action action = params->action;
+	struct ieee80211_sta *sta = params->sta;
+	u16 tid = params->tid;
+#endif
+
 	struct rt2x00_sta *sta_priv = (struct rt2x00_sta *)sta->drv_priv;
 	int ret = 0;
 

--- a/rt2x00/rt2800lib.h
+++ b/rt2x00/rt2800lib.h
@@ -226,12 +226,16 @@ int rt2800_conf_tx(struct ieee80211_hw *hw,
 		   const struct ieee80211_tx_queue_params *params);
 u64 rt2800_get_tsf(struct ieee80211_hw *hw, struct ieee80211_vif *vif);
 int rt2800_ampdu_action(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+                        struct ieee80211_ampdu_params *params
+#else
 			enum ieee80211_ampdu_mlme_action action,
 			struct ieee80211_sta *sta, u16 tid, u16 *ssn,
 			u8 buf_size
             #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 			, bool amsdu
             #endif
+#endif
             );
 int rt2800_get_survey(struct ieee80211_hw *hw, int idx,
 		      struct survey_info *survey);


### PR DESCRIPTION
ampdu_action parmaters was replaced with single ieee80211_ampdu_params
parameter in 4.6 kernel
