### PR TITLE
Kernel 4.8 compiling and new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 KDIR ?= /lib/modules/`uname -r`/build
 DST_DIR ?= /lib/modules/`uname -r`/kernel/drivers/net/wireless/
-PKG_VER ?= 2.0.7
+PKG_VER ?= 2.0.8
 
 all:
 	$(MAKE) -C $(KDIR) M=$(CURDIR)/rt2x00 modules

--- a/dkms.conf
+++ b/dkms.conf
@@ -9,5 +9,5 @@ DEST_MODULE_LOCATION[0]=/kernel/drivers/net/wireless/
 DEST_MODULE_NAME[1]=mt76xx
 DEST_MODULE_LOCATION[1]=/kernel/drivers/net/wireless/
 PACKAGE_NAME=mt7630e
-PACKAGE_VERSION=2.0.7
+PACKAGE_VERSION=2.0.8
 REMAKE_INITRD=yes

--- a/rt2x00/rt2800pci.c
+++ b/rt2x00/rt2800pci.c
@@ -1701,7 +1701,7 @@ static const struct rt2x00_ops rt2800pci_ops = {
  * RT2800pci module information.
  */
 #ifdef CONFIG_PCI
-static DEFINE_PCI_DEVICE_TABLE(rt2800pci_device_table) = {
+static const struct pci_device_id rt2800pci_device_table[] = {
 	{ PCI_DEVICE(0x14c3, 0x7630) },
 	{ PCI_DEVICE(0x14c3, 0x7650) },
 	{ 0, }


### PR DESCRIPTION
Remove macro DEFINE_PCI_DEVICE_TABLE.
Update version to 2.0.8.
