### PR TITLE
Fix compile errors on Linux 5.6 due timespec and getnstimeofday

### DIFF
--- a/rt2x00/rt2x00debug.c
+++ b/rt2x00/rt2x00debug.c
@@ -39,6 +39,9 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
 #define TIMESTRUCT timeval
 #define TIMEFUNC do_gettimeofday
+#elif  LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#define TIMESTRUCT timespec64
+#define TIMEFUNC ktime_get_real_ts64
 #else
 #define TIMESTRUCT timespec
 #define TIMEFUNC getnstimeofday


### PR DESCRIPTION
When I was tried to compile the driver on Linux 5.6 I got this errors:
```
/home/scapior/Coding/MT7630E/rt2x00/rt2x00debug.c: In function ‘rt2x00debug_dump_frame’:
/home/scapior/Coding/MT7630E/rt2x00/rt2x00debug.c:175:20: error: storage size of ‘timestamp’ i
  175 |  struct TIMESTRUCT timestamp;
      |                    ^~~~~~~~~
/home/scapior/Coding/MT7630E/rt2x00/rt2x00debug.c:44:18: error: implicit declaration of functi
   44 | #define TIMEFUNC getnstimeofday
      |                  ^~~~~~~~~~~~~~
/home/scapior/Coding/MT7630E/rt2x00/rt2x00debug.c:181:2: note: in expansion of macro ‘TIMEFUNC
  181 |  TIMEFUNC(&timestamp);
      |  ^~~~~~~~
/home/scapior/Coding/MT7630E/rt2x00/rt2x00debug.c:175:20: warning: unused variable ‘timestamp’
  175 |  struct TIMESTRUCT timestamp;
      |                    ^~~~~~~~~
```
These errors appeared due Y2038 problem fix in the Linux kernel. The solution has taken [here](https://github.com/draios/sysdig/issues/1609).